### PR TITLE
feat(teams): add operation IDs for integration and coach endpoints

### DIFF
--- a/data_models/specs/data_models/common.tsp
+++ b/data_models/specs/data_models/common.tsp
@@ -84,6 +84,13 @@ model ScoresData {
     @minValue(0.0)
     @maxValue(100.0)
     sleep?: float;
+
+
+    @doc("Biological age computed for the given day.")
+    @example(27.0)
+    @minValue(0.0)
+    @maxValue(100.0)
+    biological_age?: float;
 }
 
 model OxygenData {

--- a/schemas/ScoresData.yaml
+++ b/schemas/ScoresData.yaml
@@ -23,3 +23,10 @@ properties:
     minimum: 0
     maximum: 100
     description: Sleep score for the given day, pertaining to the previous night's sleep.
+  biological_age:
+    type: number
+    examples:
+      - 27
+    minimum: 0
+    maximum: 100
+    description: Biological age computed for the given day.

--- a/teams.yml
+++ b/teams.yml
@@ -97,6 +97,7 @@ paths:
                     description: indicates that an error happened (value is error)
   /integrations/detailed:
     get:
+      operationId: getDetailedIntegrations
       summary: Get detailed information about available integrations
       description: Returns detailed information about available providers, including required login fields and logos.
       security: []
@@ -111,6 +112,7 @@ paths:
         - Integrations
   /coaches:
     get:
+      operationId: listCoaches
       summary: List all coaches
       responses:
         '200':
@@ -122,6 +124,7 @@ paths:
       tags:
         - Coaches
     post:
+      operationId: createCoach
       summary: Create a new coach
       description: Registers a new coach with credentials and integration specifics.
       requestBody:
@@ -146,6 +149,7 @@ paths:
   /coaches/{coachId}:
     delete:
       summary: Delete a coach
+      operationId: deleteCoach
       description: Deletes a coach and all associated athletes, activities, and tests.
       parameters:
         - name: coachId
@@ -167,6 +171,7 @@ paths:
         - Coaches
   /coaches/{coachId}/athletes:
     get:
+      operationId: getAthletesForCoach
       summary: Retrieve all athletes under a specific coach
       parameters:
         - name: coachId
@@ -192,6 +197,7 @@ paths:
           - Coaches
   /coaches/{coachId}/activities:
     get:
+      operationId: getActivitiesForCoach
       summary: Retrieve all activities recorded by athletes under a specific coach
       parameters:
         - name: coachId
@@ -229,6 +235,7 @@ paths:
         - Coaches
   /coaches/{coachId}/activities/metrics/schema:
     get:
+      operationId:  getActivityMetricsSchemaForCoach
       summary: Retrieve activity metrics schema for a coach
       description: Returns the schema of activity metrics available for the specified coach.
       parameters:
@@ -262,6 +269,7 @@ paths:
         - Coaches
   /coaches/{coachId}/tests:
     get:
+      operationId: getTestsForCoach
       summary: Retrieve all tests conducted by athletes under a specific coach
       parameters:
         - name: coachId
@@ -299,12 +307,15 @@ paths:
         - Coaches
   /athletes:
     get:
+      operationId: getAthletes
       summary: List all athletes
       responses:
         '200':
           description: An array of athletes
           content:
-            $ref: '#/components/schemas/AthletesReturned'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AthletesReturned'
       tags:
         - Athletes
     patch:
@@ -370,6 +381,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
   /athletes/{athleteId}:
     get:
+      operationId: getAthlete
       summary: Retrieve a specific athlete by their ID
       parameters:
         - name: athleteId
@@ -387,6 +399,7 @@ paths:
       tags:
         - Athletes
     patch:
+      operationId: updateAthlete
       summary: Update an athlete's information
       parameters:
         - name: athleteId
@@ -450,7 +463,7 @@ components:
           type: string
           description: "Identifier of the coach on the provider's systems"
           readOnly: true
-        reference_id:     
+        reference_id:
           type: string
           description: "ID of the coach on your system"
         region:
@@ -569,7 +582,6 @@ components:
           description: "Indicates if the athlete is from the home team"
         participation:
           $ref: '#/components/schemas/ParticipationType'
-          nullable: true
           description: "Type of participation in an activity"
         function:
           type: string
@@ -805,7 +817,7 @@ components:
         movement:
           $ref: '#/components/schemas/BiomechanicalMovement'
           default: -1
-  
+
     Test:
       type: object
       properties:
@@ -908,20 +920,20 @@ components:
         type:
           type: string
           format: uri
-          examples: 
+          examples:
             - "https://api.tryterra.co/probs/not-found"
         title:
           type: string
-          examples: 
+          examples:
             - "Resource Not Found"
         status:
           type: integer
           format: int32
-          examples: 
+          examples:
             - 404
         detail:
           type: string
-          examples: 
+          examples:
             - "The coach with the provided ID does not exist."
         instance:
           type: string
@@ -1008,7 +1020,6 @@ components:
           description: "Data type of the metric (e.g., integer, float)."
         sport:
           $ref: '#/components/schemas/Sport'
-          nullable: true
           description: "Sport associated with the metric."
     IntegrationsResponse:
       type: object

--- a/v5-bundled.yaml
+++ b/v5-bundled.yaml
@@ -353,7 +353,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -514,7 +514,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -604,7 +604,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -892,7 +892,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1003,7 +1003,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1114,7 +1114,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1403,7 +1403,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1486,6 +1486,13 @@ paths:
       operationId: PlannedWorkout_Write
       description: Used to post workout plans users can follow on their wearable. This can be strength workouts (sets, reps, weight lifted) or cardio workouts (warmup, intervals of different intensities, cooldown etc)
       summary: Post workout plans to a provider
+      parameters:
+        - name: user_id
+          in: query
+          description: Terra user ID (UUID format) to retrieve data for
+          schema:
+            type: string
+          required: true
       requestBody:
         content:
           application/json:
@@ -1582,7 +1589,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false

--- a/v5.yaml
+++ b/v5.yaml
@@ -350,7 +350,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -517,7 +517,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -610,7 +610,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -920,7 +920,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1034,7 +1034,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1148,7 +1148,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1460,7 +1460,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false
@@ -1651,7 +1651,7 @@ paths:
         - name: to_webhook
           in: query
           description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: false)
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
           schema:
             type: boolean
           required: false

--- a/v5.yaml
+++ b/v5.yaml
@@ -1546,6 +1546,13 @@ paths:
         Used to post workout plans users can follow on their wearable. This can be strength workouts (sets, reps, weight lifted)
         or cardio workouts (warmup, intervals of different intensities, cooldown etc)
       summary: Post workout plans to a provider
+      parameters:
+        - name: user_id
+          in: query
+          description: Terra user ID (UUID format) to retrieve data for
+          schema:
+            type: string
+          required: true
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
…biological age field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added biological_age (0–100) to Scores data.
  * POST /plannedWorkout now requires a user_id query parameter for per-user targeting.

* Behavior Changes
  * to_webhook now defaults to true when omitted across multiple endpoints (e.g., activity, athlete, body, daily, menstruation, nutrition, sleep, plannedWorkout).

* Documentation
  * Updated endpoint descriptions to reflect the new to_webhook default and the required user_id on POST /plannedWorkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->