### PR TITLE
Seror/hormone v3 endpoint

### DIFF
--- a/data_models/main.tsp
+++ b/data_models/main.tsp
@@ -10,6 +10,8 @@ import "./specs/data_models/Nutrition.tsp";
 import "./specs/data_models/Menstruation.tsp";
 import "./specs/data_models/Athlete.tsp";
 import "./specs/data_models/Body.tsp";
+import "./specs/data_models/Hormone.tsp";
+import "./specs/data_models/Connection.tsp";
 import "./specs/data_models/Events.tsp";
 
 using JsonSchema;

--- a/data_models/package-lock.json
+++ b/data_models/package-lock.json
@@ -17,7 +17,8 @@
         "@typespec/compiler": "latest",
         "eslint": "^9.15.0",
         "prettier": "^3.3.3",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "typescript-eslint": "^8.59.3"
       },
       "peerDependencies": {
         "@typespec/compiler": "latest"
@@ -47,9 +48,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -66,9 +67,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -710,21 +711,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
-      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/type-utils": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -734,23 +734,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.44.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
-      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -760,20 +760,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
-      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.44.1",
-        "@typescript-eslint/types": "^8.44.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -783,18 +783,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
-      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -805,9 +805,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
-      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -818,21 +818,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
-      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1",
-        "@typescript-eslint/utils": "8.44.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -842,14 +842,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
-      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -861,22 +861,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
-      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.44.1",
-        "@typescript-eslint/tsconfig-utils": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/visitor-keys": "8.44.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -886,20 +885,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
-      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.44.1",
-        "@typescript-eslint/types": "8.44.1",
-        "@typescript-eslint/typescript-estree": "8.44.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -909,19 +908,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.44.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
-      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.44.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -932,13 +931,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1097,13 +1096,26 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1247,9 +1259,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1755,13 +1767,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1785,9 +1790,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -1987,16 +1992,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2315,9 +2320,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2457,6 +2462,54 @@
       "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
       "license": "ISC"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -2482,9 +2535,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2531,6 +2584,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/data_models/package.json
+++ b/data_models/package.json
@@ -23,7 +23,8 @@
     "@typespec/compiler": "latest",
     "eslint": "^9.15.0",
     "prettier": "^3.3.3",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^8.59.3"
   },
   "scripts": {
     "build": "tsc",

--- a/data_models/promote.sh
+++ b/data_models/promote.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 # This script promotes the generated JSON schemas to the schemas directory.
 
 rm -rf ../schemas/*

--- a/data_models/specs/data_models/Connection.tsp
+++ b/data_models/specs/data_models/Connection.tsp
@@ -1,0 +1,37 @@
+namespace Terra.Models;
+
+// Connection Model
+//
+// v3-native connection block, used in place of the legacy `user` block on
+// v3 endpoint responses. Identifies a single connected provider account
+// for an end user.
+model Connection {
+    @doc("Terra connection ID.")
+    @example(75001)
+    id: integer;
+
+    @doc("External user identifier provided at connect time.")
+    @example("user_external_ref_123")
+    reference_id?: string;
+
+    @doc("RFC3339 timestamp of when the connection was first authorised.")
+    @example("2026-04-22T11:00:00Z")
+    created_at: string;
+
+    @doc("Uppercase provider slug, e.g. MIRA or FITBIT.")
+    @example("MIRA")
+    provider: string;
+
+    @doc("RFC3339 timestamp of the last poll Terra ran against the provider for this connection. May be null for webhook-only flows.")
+    last_polled_at?: string;
+
+    @doc("RFC3339 timestamp of the last time Terra received any data from the provider for this connection.")
+    last_updated_at?: string;
+
+    @doc("RFC3339 timestamp of the most recent stored sample. May lag last_updated_at when fetches return no new data.")
+    most_recent_data_at?: string;
+
+    @doc("Granted OAuth scopes. Empty array for providers without scopes (e.g. Mira).")
+    scopes: string[];
+}
+// End of Connection Model

--- a/data_models/specs/data_models/Hormone.tsp
+++ b/data_models/specs/data_models/Hormone.tsp
@@ -1,0 +1,35 @@
+namespace Terra.Models;
+
+// Hormone Model
+//
+// One entry per test event. Each entry collapses all hormones measured at a
+// single `timestamp` into a single object, with one field per hormone.
+// Hormones not measured at that test event appear as null in the actual
+// payload. Unlike v2 data types, hormone has no `metadata` wrapper; the
+// top-level `timestamp` field serves as the unique identifier per entry.
+model HormoneSample {
+    @doc("ISO-8601 timestamp of the test event, including timezone offset.")
+    @example("2026-05-07T08:00:00+02:00")
+    timestamp: string;
+
+    @doc("Luteinizing hormone reading, milli-international units per millilitre.")
+    @example(5.2)
+    lh_mIU_per_ml?: float;
+
+    @doc("Estrone-3-glucuronide reading, nanograms per millilitre. Urinary estrogen metabolite, rises before ovulation.")
+    @example(108.5)
+    e3g_ng_per_ml?: float;
+
+    @doc("Pregnanediol glucuronide reading, micrograms per millilitre. Urinary progesterone metabolite, confirms ovulation.")
+    @example(2.4)
+    pdg_ug_per_ml?: float;
+
+    @doc("Human chorionic gonadotropin reading, milli-international units per millilitre. Pregnancy hormone.")
+    @example(0.8)
+    hcg_mIU_per_ml?: float;
+
+    @doc("Follicle-stimulating hormone reading, milli-international units per millilitre. Ovarian reserve / menopause indicator.")
+    @example(4.8)
+    fsh_mIU_per_ml?: float;
+}
+// End of Hormone Model

--- a/schemas/Connection.yaml
+++ b/schemas/Connection.yaml
@@ -1,36 +1,36 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/Connection.yaml
 type: object
-description: |
-  Identifies a Terra connection (one connected provider account for an end user).
-  Used in v3 endpoint responses in place of the legacy `user` block.
 properties:
   id:
     type: integer
-    format: int64
+    examples:
+      - 75001
     description: Terra connection ID.
-    example: 75001
   reference_id:
-    type: [string, "null"]
+    type: string
+    examples:
+      - user_external_ref_123
     description: External user identifier provided at connect time.
-    example: "user_external_ref_123"
   created_at:
     type: string
+    examples:
+      - 2026-04-22T11:00:00Z
     description: RFC3339 timestamp of when the connection was first authorised.
-    example: "2026-04-22T11:00:00Z"
   provider:
     type: string
-    description: Uppercase provider slug, e.g. "MIRA", "FITBIT".
-    example: "MIRA"
+    examples:
+      - MIRA
+    description: Uppercase provider slug, e.g. MIRA or FITBIT.
   last_polled_at:
-    type: [string, "null"]
+    type: string
     description: RFC3339 timestamp of the last poll Terra ran against the provider for this connection. May be null for webhook-only flows.
   last_updated_at:
-    type: [string, "null"]
+    type: string
     description: RFC3339 timestamp of the last time Terra received any data from the provider for this connection.
   most_recent_data_at:
-    type: [string, "null"]
-    description: RFC3339 timestamp of the most recent stored sample. May lag `last_updated_at` when fetches return no new data.
+    type: string
+    description: RFC3339 timestamp of the most recent stored sample. May lag last_updated_at when fetches return no new data.
   scopes:
     type: array
     items:

--- a/schemas/Connection.yaml
+++ b/schemas/Connection.yaml
@@ -1,0 +1,43 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/Connection.yaml
+type: object
+description: |
+  Identifies a Terra connection (one connected provider account for an end user).
+  Used in v3 endpoint responses in place of the legacy `user` block.
+properties:
+  id:
+    type: integer
+    format: int64
+    description: Terra connection ID.
+    example: 75001
+  reference_id:
+    type: [string, "null"]
+    description: External user identifier provided at connect time.
+    example: "user_external_ref_123"
+  created_at:
+    type: string
+    description: RFC3339 timestamp of when the connection was first authorised.
+    example: "2026-04-22T11:00:00Z"
+  provider:
+    type: string
+    description: Uppercase provider slug, e.g. "MIRA", "FITBIT".
+    example: "MIRA"
+  last_polled_at:
+    type: [string, "null"]
+    description: RFC3339 timestamp of the last poll Terra ran against the provider for this connection. May be null for webhook-only flows.
+  last_updated_at:
+    type: [string, "null"]
+    description: RFC3339 timestamp of the last time Terra received any data from the provider for this connection.
+  most_recent_data_at:
+    type: [string, "null"]
+    description: RFC3339 timestamp of the most recent stored sample. May lag `last_updated_at` when fetches return no new data.
+  scopes:
+    type: array
+    items:
+      type: string
+    description: Granted OAuth scopes. Empty array for providers without scopes (e.g. Mira).
+required:
+  - id
+  - created_at
+  - provider
+  - scopes

--- a/schemas/HormoneSample.yaml
+++ b/schemas/HormoneSample.yaml
@@ -1,36 +1,36 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/HormoneSample.yaml
 type: object
-description: |
-  One hormone test event. Each entry collapses all hormones measured at a single
-  `timestamp` into a single object, with one field per hormone. Hormones not
-  measured at that test event appear as `null`. Unlike v2 data types, hormone
-  has no `metadata` wrapper; `timestamp` lives at the top level and serves as the
-  unique identifier per entry.
 properties:
   timestamp:
     type: string
+    examples:
+      - 2026-05-07T08:00:00+02:00
     description: ISO-8601 timestamp of the test event, including timezone offset.
-    example: "2026-05-07T08:00:00+02:00"
   lh_mIU_per_ml:
-    type: [number, "null"]
+    type: number
+    examples:
+      - 5.2
     description: Luteinizing hormone reading, milli-international units per millilitre.
-    example: 5.2
   e3g_ng_per_ml:
-    type: [number, "null"]
-    description: Estrone-3-glucuronide reading, nanograms per millilitre. Urinary estrogen metabolite.
-    example: 108.5
+    type: number
+    examples:
+      - 108.5
+    description: Estrone-3-glucuronide reading, nanograms per millilitre. Urinary estrogen metabolite, rises before ovulation.
   pdg_ug_per_ml:
-    type: [number, "null"]
+    type: number
+    examples:
+      - 2.4
     description: Pregnanediol glucuronide reading, micrograms per millilitre. Urinary progesterone metabolite, confirms ovulation.
-    example: 2.4
   hcg_mIU_per_ml:
-    type: [number, "null"]
+    type: number
+    examples:
+      - 0.8
     description: Human chorionic gonadotropin reading, milli-international units per millilitre. Pregnancy hormone.
-    example: 0.8
   fsh_mIU_per_ml:
-    type: [number, "null"]
+    type: number
+    examples:
+      - 4.8
     description: Follicle-stimulating hormone reading, milli-international units per millilitre. Ovarian reserve / menopause indicator.
-    example: 4.8
 required:
   - timestamp

--- a/schemas/HormoneSample.yaml
+++ b/schemas/HormoneSample.yaml
@@ -1,0 +1,36 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/HormoneSample.yaml
+type: object
+description: |
+  One hormone test event. Each entry collapses all hormones measured at a single
+  `timestamp` into a single object, with one field per hormone. Hormones not
+  measured at that test event appear as `null`. Unlike v2 data types, hormone
+  has no `metadata` wrapper; `timestamp` lives at the top level and serves as the
+  unique identifier per entry.
+properties:
+  timestamp:
+    type: string
+    description: ISO-8601 timestamp of the test event, including timezone offset.
+    example: "2026-05-07T08:00:00+02:00"
+  lh_mIU_per_ml:
+    type: [number, "null"]
+    description: Luteinizing hormone reading, milli-international units per millilitre.
+    example: 5.2
+  e3g_ng_per_ml:
+    type: [number, "null"]
+    description: Estrone-3-glucuronide reading, nanograms per millilitre. Urinary estrogen metabolite.
+    example: 108.5
+  pdg_ug_per_ml:
+    type: [number, "null"]
+    description: Pregnanediol glucuronide reading, micrograms per millilitre. Urinary progesterone metabolite, confirms ovulation.
+    example: 2.4
+  hcg_mIU_per_ml:
+    type: [number, "null"]
+    description: Human chorionic gonadotropin reading, milli-international units per millilitre. Pregnancy hormone.
+    example: 0.8
+  fsh_mIU_per_ml:
+    type: [number, "null"]
+    description: Follicle-stimulating hormone reading, milli-international units per millilitre. Ovarian reserve / menopause indicator.
+    example: 4.8
+required:
+  - timestamp

--- a/v5.yaml
+++ b/v5.yaml
@@ -1117,7 +1117,10 @@ paths:
     get:
       summary: Retrieve hormone data for a given connection ID
       description:
-        Fetches hormone test events (LH, E3G, PDG, HCG, FSH) for a given connection. Each entry is one test event; hormones not measured at that event appear as null. v3 endpoint, uses different authentication headers from v2 endpoints.
+        Fetches hormone test events (LH, E3G, PDG, HCG, FSH) for a given
+        connection. Each entry is one test event; hormones not measured at
+        that event appear as null. v3 endpoint, uses x-terra-client-id and
+        x-terra-client-secret headers for authentication.
       tags:
         - Hormone
       operationId: Hormone_Fetch
@@ -1145,13 +1148,6 @@ paths:
             type: string
             format: date
           required: false
-        - name: to_webhook
-          in: query
-          description: |
-            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
-          schema:
-            type: boolean
-          required: false
       responses:
         "200":
           description: Returned upon successful data request
@@ -1170,13 +1166,11 @@ paths:
                       type:
                         type: string
                         enum: [hormone]
-                      version:
-                        type: string
-                        example: "2022-03-16"
                   - $ref: "#/components/schemas/NoDataReturned"
-                  - $ref: "#/components/schemas/DataSentToWebhook"
         "400":
-          description: Returned when one or more parameters is malformed
+          description:
+            Returned when one or more parameters is malformed - an appropriate
+            error message will be returned
           content:
             application/json:
               schema:
@@ -1188,21 +1182,23 @@ paths:
                   status:
                     type: string
                     enum: [error]
+                    description: indicates that an error happened (value is error)
         "401":
-          description: Returned when v3 credentials (x-terra-client-id and x-terra-client-secret) are invalid or missing
+          description:
+            Returned when v3 credentials (x-terra-client-id and
+            x-terra-client-secret) are invalid or missing
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   message:
-                    description: a detailed message describing the error
+                    description: An error message
                     type: string
-                  status:
-                    type: string
-                    enum: [error]
+                    example: unauthorized
         "404":
-          description: Returned when the connection ID does not exist
+          description:
+            Returned when the connection ID does not exist
           content:
             application/json:
               schema:
@@ -1214,6 +1210,7 @@ paths:
                   status:
                     type: string
                     enum: [error]
+                    description: indicates that an error happened (value is error)
   /nutrition:
     get:
       summary: Retrieve nutrition log data for a given user ID

--- a/v5.yaml
+++ b/v5.yaml
@@ -1111,6 +1111,109 @@ paths:
                     type: string
                     enum: [error]
                     description: indicates that an error happened (value is error)
+  /connections/{connection_id}/hormone:
+    servers:
+      - url: https://api.tryterra.co/v3
+    get:
+      summary: Retrieve hormone data for a given connection ID
+      description:
+        Fetches hormone test events (LH, E3G, PDG, HCG, FSH) for a given connection. Each entry is one test event; hormones not measured at that event appear as null. v3 endpoint, uses different authentication headers from v2 endpoints.
+      tags:
+        - Hormone
+      operationId: Hormone_Fetch
+      security:
+        - TerraClientId: []
+          TerraClientSecret: []
+      parameters:
+        - name: connection_id
+          in: path
+          description: Terra connection ID
+          schema:
+            type: string
+          required: true
+        - name: start_date
+          in: query
+          description: Start date for data query (ISO-8601 date, YYYY-MM-DD)
+          schema:
+            type: string
+            format: date
+          required: true
+        - name: end_date
+          in: query
+          description: End date for data query (ISO-8601 date, YYYY-MM-DD)
+          schema:
+            type: string
+            format: date
+          required: false
+        - name: to_webhook
+          in: query
+          description: |
+            Boolean flag specifying whether to send the data retrieved to the webhook instead of in the response (default: true if not provided)
+          schema:
+            type: boolean
+          required: false
+      responses:
+        "200":
+          description: Returned upon successful data request
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      connection:
+                        $ref: "#/components/schemas/Connection"
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/HormoneSample"
+                      type:
+                        type: string
+                        enum: [hormone]
+                      version:
+                        type: string
+                        example: "2022-03-16"
+                  - $ref: "#/components/schemas/NoDataReturned"
+                  - $ref: "#/components/schemas/DataSentToWebhook"
+        "400":
+          description: Returned when one or more parameters is malformed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: a detailed message describing the error
+                    type: string
+                  status:
+                    type: string
+                    enum: [error]
+        "401":
+          description: Returned when v3 credentials (x-terra-client-id and x-terra-client-secret) are invalid or missing
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: a detailed message describing the error
+                    type: string
+                  status:
+                    type: string
+                    enum: [error]
+        "404":
+          description: Returned when the connection ID does not exist
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    description: a detailed message describing the error
+                    type: string
+                  status:
+                    type: string
+                    enum: [error]
   /nutrition:
     get:
       summary: Retrieve nutrition log data for a given user ID
@@ -2122,6 +2225,16 @@ components:
       in: header
       name: dev-id
       description: Your developer ID for authentication and tracking
+    TerraClientId:
+      type: apiKey
+      in: header
+      name: x-terra-client-id
+      description: Your Terra client ID, used to authenticate v3 endpoints alongside x-terra-client-secret
+    TerraClientSecret:
+      type: apiKey
+      in: header
+      name: x-terra-client-secret
+      description: Your Terra client secret, used to authenticate v3 endpoints alongside x-terra-client-id
   schemas:
     WidgetSessionParams:
       type: object
@@ -2252,6 +2365,10 @@ components:
       $ref: "https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/Daily.yaml"
     Menstruation:
       $ref: "https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/Menstruation.yaml"
+    HormoneSample:
+      $ref: "https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/HormoneSample.yaml"
+    Connection:
+      $ref: "https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/Connection.yaml"
     Nutrition:
       $ref: "https://raw.githubusercontent.com/tryterra/openapi/refs/heads/master/schemas/Nutrition.yaml"
     Sleep:


### PR DESCRIPTION
Adds the new `hormone` data type to the Health & Fitness API OpenAPI spec, mirroring the v3 endpoint shipped in terra-v6 PR #753 (Mira integration + hormones). This is the first v3 endpoint in v5.yaml.

Changes:
- New path `/connections/{connection_id}/hormone` in v5.yaml, with a per-path server override to https://api.tryterra.co/v3 and a per-operation security override to the new v3 auth schemes
- Two new security schemes: `TerraClientId` (x-terra-client-id header) and `TerraClientSecret` (x-terra-client-secret header), for v3 endpoint auth
- New schema `schemas/HormoneSample.yaml`: flat shape with timestamp + 5 hormone fields (lh_mIU_per_ml, e3g_ng_per_ml, pdg_ug_per_ml, hcg_mIU_per_ml, fsh_mIU_per_ml). Each field nullable; nulls are emitted in the payload, not omitted.
- New schema `schemas/Connection.yaml`: v3-native connection block (id, created_at, provider, scopes, etc.), replaces the legacy `user` block on v3 responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint for retrieving hormone test results and events associated with a connection
  * Hormone data retrieval supports date range filtering with start and end dates
  * Hormone test results include multiple hormone measurements with timestamps
  * Added header-based authentication security requirements for accessing hormone endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tryterra/openapi/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->