### PR TITLE
spec: no-destinations 200 is now a success body, not a problem

### DIFF
--- a/apis/v2.yaml
+++ b/apis/v2.yaml
@@ -1161,24 +1161,18 @@ components:
       description: >
         Returned with HTTP 200 when `to_webhook` is true but the connection has
         no destination configured, so there is nowhere to deliver the requested
-        data. The body uses the problem shape but is not an error.
+        data.
       properties:
-        type:
+        status:
           type: string
-          example: about:blank
-        title:
-          type: string
-          example: ok
-        instance:
-          type: string
-          example: /activity
-        detail:
+          enum: [success]
+          example: success
+        message:
           type: string
           example: no destinations available for this connection
       required:
-        - type
-        - title
-        - instance
+        - status
+        - message
     DataSentToWebhook:
       type: object
       description: >

--- a/dist/v2-bundled.yaml
+++ b/dist/v2-bundled.yaml
@@ -1461,24 +1461,19 @@ components:
     NoDestinationsAvailable:
       type: object
       description: |
-        Returned with HTTP 200 when `to_webhook` is true but the connection has no destination configured, so there is nowhere to deliver the requested data. The body uses the problem shape but is not an error.
+        Returned with HTTP 200 when `to_webhook` is true but the connection has no destination configured, so there is nowhere to deliver the requested data.
       properties:
-        type:
+        status:
           type: string
-          example: about:blank
-        title:
-          type: string
-          example: ok
-        instance:
-          type: string
-          example: /activity
-        detail:
+          enum:
+            - success
+          example: success
+        message:
           type: string
           example: no destinations available for this connection
       required:
-        - type
-        - title
-        - instance
+        - status
+        - message
     DataSentToWebhook:
       type: object
       description: |


### PR DESCRIPTION
Companion to **tryterra/terra-v6#1285**. When `to_webhook=true` and the connection has no destination, the v2 API now returns a normal success body instead of a problem-shaped 200:

- before: `application/problem+json` `{type, title:"ok", instance, detail}`
- after: `application/json` `{status:"success", message:"no destinations available for this connection"}`

Updates `NoDestinationsAvailable` in `apis/v2.yaml` (and regenerates `dist/v2-bundled.yaml`). Validated live — the running api returns the new shape. Lint + bundle-drift gate green.

**Merge after** terra-v6#1285 so the spec doesn't get ahead of the deployed behavior.