### PR TITLE
spec: no-destinations is a 400, drop the NoDestinationsAvailable 200 shape

### DIFF
--- a/apis/v2.yaml
+++ b/apis/v2.yaml
@@ -295,7 +295,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -332,7 +331,6 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/AthleteCollection"
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -403,7 +401,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -474,7 +471,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -547,7 +543,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -620,7 +615,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -693,7 +687,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -814,7 +807,6 @@ paths:
                       type:
                         type: [string, "null"]
                   - $ref: "#/components/schemas/DataSentToWebhook"
-                  - $ref: "#/components/schemas/NoDestinationsAvailable"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1156,29 +1148,6 @@ components:
           example: "https://myapp.com/failure"
     User:
       $ref: "../schemas/TerraUser.yaml"
-    NoDestinationsAvailable:
-      type: object
-      description: >
-        Returned with HTTP 200 when `to_webhook` is true but the connection has
-        no destination configured, so there is nowhere to deliver the requested
-        data. The body uses the problem shape but is not an error.
-      properties:
-        type:
-          type: string
-          example: about:blank
-        title:
-          type: string
-          example: ok
-        instance:
-          type: string
-          example: /activity
-        detail:
-          type: string
-          example: no destinations available for this connection
-      required:
-        - type
-        - title
-        - instance
     DataSentToWebhook:
       type: object
       description: >

--- a/dist/v2-bundled.yaml
+++ b/dist/v2-bundled.yaml
@@ -300,7 +300,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -337,7 +336,6 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/AthleteCollection'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -410,7 +408,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -483,7 +480,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -556,7 +552,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -629,7 +624,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -702,7 +696,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -817,7 +810,6 @@ paths:
                           - string
                           - 'null'
                   - $ref: '#/components/schemas/DataSentToWebhook'
-                  - $ref: '#/components/schemas/NoDestinationsAvailable'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1458,27 +1450,6 @@ components:
           example: https://myapp.com/failure
     User:
       $ref: '#/components/schemas/TerraUser'
-    NoDestinationsAvailable:
-      type: object
-      description: |
-        Returned with HTTP 200 when `to_webhook` is true but the connection has no destination configured, so there is nowhere to deliver the requested data. The body uses the problem shape but is not an error.
-      properties:
-        type:
-          type: string
-          example: about:blank
-        title:
-          type: string
-          example: ok
-        instance:
-          type: string
-          example: /activity
-        detail:
-          type: string
-          example: no destinations available for this connection
-      required:
-        - type
-        - title
-        - instance
     DataSentToWebhook:
       type: object
       description: |


### PR DESCRIPTION
Companion to **tryterra/terra-v6#1286**. A connection with no destination now returns a **400** (problem+json), already documented via the shared `BadRequest` response on every data endpoint — so the `NoDestinationsAvailable` 200 shape is removed (schema + its 8 data-`200` `oneOf` members). The data `200` is now `{sync data document | DataSentToWebhook}`.

Supersedes #10 (which moved it to a 200 success body) — closing that.

Lint + bundle-drift green; `dist/v2-bundled.yaml` regenerated. **Merge after** terra-v6#1286.